### PR TITLE
enabling encryption over the wire

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -31,7 +31,16 @@ resource "google_redis_instance" "redis" {
   replica_count      = local.is_highly_available ? var.read_replicas : null
 
   # OSS Redis AUTH
-  auth_enabled = true
+  auth_enabled            = true
+  transit_encryption_mode = "SERVER_AUTHENTICATION"
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to transit_encryption_mode
+      # make adding this backwards-compat with existing instances
+      transit_encryption_mode,
+    ]
+  }
 
   depends_on = [
     module.apis


### PR DESCRIPTION
Didn't get this the first pass, auth + encryption is better than just auth since the network can be multi-tenant.

- Made a redis
- added this attribute, w/ the lifecycle hook
- no updates! so it _is_ backwards-compat 💪 

<img width="1489" alt="Screen Shot 2022-06-08 at 10 53 38 AM" src="https://user-images.githubusercontent.com/651833/172684515-2daa1096-a60f-474b-aef6-5c6577a5c582.png">
