### PR TITLE
make redis TLS optional

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -49,6 +49,12 @@ params:
       description: Number of read replicas to provision. Must be an integer between 1 and 5.
       minimum: 1
       maximum: 5
+    tls_enabled:
+      type: boolean
+      title: TLS Enabled
+      description: Enable TLS encryption
+      default: true
+      $md.immutable: true
 
 connections:
   required:

--- a/src/_artifacts.tf
+++ b/src/_artifacts.tf
@@ -9,6 +9,12 @@ locals {
     password = google_redis_instance.redis.auth_string
     hostname = google_redis_instance.redis.host
     port     = google_redis_instance.redis.port
+    certificate = var.tls_enabled ? {
+      cert             = google_redis_instance.redis.server_ca_certs[0].cert
+      create_time      = google_redis_instance.redis.server_ca_certs[0].create_time
+      expiration_time  = google_redis_instance.redis.server_ca_certs[0].expire_time
+      sha1_fingerprint = google_redis_instance.redis.server_ca_certs[0].sha1_fingerprint
+    } : null
   }
 
   specs_cache = {

--- a/src/main.tf
+++ b/src/main.tf
@@ -32,13 +32,13 @@ resource "google_redis_instance" "redis" {
 
   # OSS Redis AUTH
   auth_enabled            = true
-  transit_encryption_mode = "SERVER_AUTHENTICATION"
+  transit_encryption_mode = var.tls_enabled ? "SERVER_AUTHENTICATION" : "DISABLED"
 
   lifecycle {
     ignore_changes = [
       # Ignore changes to transit_encryption_mode
       # make adding this backwards-compat with existing instances
-      transit_encryption_mode,
+      transit_encryption_mode
     ]
   }
 


### PR DESCRIPTION
part of supporting TLS in GCP